### PR TITLE
Update redirect to respect base_url after authentication

### DIFF
--- a/datasette_auth_github/views.py
+++ b/datasette_auth_github/views.py
@@ -85,7 +85,7 @@ async def github_auth_callback(datasette, request, scope, receive, send):
     extras = await load_orgs_and_teams(config, profile, access_token)
     actor.update(extras)
 
-    # Set a signed cookie and redirect to homepage
-    response = Response.redirect("/")
+   # Set a signed cookie and redirect to homepage (respecting 'base_url' setting)
+    response = Response.redirect(datasette.urls.path("/"))
     response.set_cookie("ds_actor", datasette.sign({"a": actor}, "actor"))
     return response


### PR DESCRIPTION
Updates the logic for redirecting once a user is authenticated. After the change it respects the base_url setting when generating the redirect URL.

For example, if you run your datasette as follows:
`datasette . --setting base_url /tools/datasette/ -p 8009`
After successfull authentication you'll be redirected to:
 `example.com/tools/datasette/` 
instead of just:
`example.com/`